### PR TITLE
Upgrade juice dependency to latest version: 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "consolidate": "^0.14.2",
     "debug": "^2.2.0",
     "glob": "^6.0.0",
-    "juice": "^2.0.0",
+    "juice": "^4.1.0",
     "lodash": "^4.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This fixes issue related to clean-css (Cannot find module '../images/url-rewriter') when using yarn as reported in #224 