### PR TITLE
add "deeplink" as template

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "email-templates",
   "description": "Node.js module for rendering beautiful emails with ejs, pug, swig, hbs, jade or handlebars templates and email-friendly inline CSS using juice.",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "author": "Nick Baugh <niftylettuce@gmail.com>",
   "contributors": [
     {

--- a/src/main.js
+++ b/src/main.js
@@ -35,14 +35,14 @@ function template (templateDirectory, options) {
       return callback(null, function (locals, dir, next) {
         et.render(locals, function (err, result) {
           result = result || {}
-          next(err, result.html, result.text, result.subject)
+          next(err, result.html, result.text, result.subject, result.deeplink)
         })
       })
     }
 
     et.render(locals, function (err, result) {
       result = result || {}
-      callback(err, result.html, result.text, result.subject)
+      callback(err, result.html, result.text, result.subject, result.deeplink)
     })
   }
 }


### PR DESCRIPTION
we are using this module heavily for our email and push notificaiton renderings, but needed one additioanl "file" to get rendered to solve all our problems :)

Therefore I added "deeplink" as another possible template like "subject". A great feature request by the way would be to specify as many custom templates as you want to. This would allow a lot of new use cases for this module and doesn't really add any complexity.

let me know what you think about my feature request, or at least about this PR. would be great to see something like this in master :)

simon